### PR TITLE
Fix the position of the scale text

### DIFF
--- a/madge-example/src/main/java/com/example/madge/FooView.java
+++ b/madge-example/src/main/java/com/example/madge/FooView.java
@@ -1,0 +1,45 @@
+package com.example.madge;
+
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.graphics.drawable.Drawable;
+import android.util.AttributeSet;
+import android.view.View;
+
+public class FooView extends View {
+    Bitmap bitmap;
+    Paint paint;
+
+    public FooView(Context context) {
+        this(context, null);
+    }
+
+    public FooView(Context context, AttributeSet attrs) {
+        this(context, attrs, 0);
+    }
+
+    public FooView(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+
+        Drawable drawable = getResources().getDrawable(R.drawable.app_icon);
+        int w = drawable.getIntrinsicWidth();
+        int h = drawable.getIntrinsicHeight();
+
+        bitmap = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888);
+        Canvas canvas = new Canvas(bitmap);
+        drawable.setBounds(0, 0, w, h);
+        drawable.draw(canvas);
+
+        paint = new Paint();
+    }
+
+    @Override
+    protected void onDraw(Canvas canvas) {
+        float x = (getWidth() - bitmap.getWidth()) / 2;
+        float y = (getHeight() - bitmap.getHeight()) / 2;
+        canvas.drawBitmap(bitmap, x, y, paint);
+    }
+
+}

--- a/madge-example/src/main/res/layout/example.xml
+++ b/madge-example/src/main/res/layout/example.xml
@@ -25,4 +25,7 @@
       android:layout_marginTop="60dp"
       android:src="@drawable/app_icon"
       />
+  <com.example.madge.FooView
+      android:layout_width="match_parent"
+      android:layout_height="100dp" />
 </LinearLayout>

--- a/madge/src/main/java/com/jakewharton/madge/MadgeCanvas.java
+++ b/madge/src/main/java/com/jakewharton/madge/MadgeCanvas.java
@@ -169,7 +169,7 @@ final class MadgeCanvas extends DelegateCanvas {
   @Override public void drawBitmap(Bitmap bitmap, float left, float top, Paint paint) {
     super.drawBitmap(overlayPixels(bitmap), left, top, paint);
     if (overlayRatioEnabled) {
-      drawScaleValue(bitmap, 1, 1, 0, 0);
+      drawScaleValue(bitmap, 1, 1, (int)left, (int)top);
     }
   }
 


### PR DESCRIPTION
If a custom View draws a bitmap at a position other than 0,0 the scale text is incorrectly positioned:

![without_fix](https://cloud.githubusercontent.com/assets/2290987/16617407/6eda3332-437b-11e6-9b4f-0e6955746404.png)

updating `MadgeCanvas` to use `left` and `top` positions the text correctly:

![with_fix](https://cloud.githubusercontent.com/assets/2290987/16617431/8a12a36e-437b-11e6-86b1-b51fc3d2332a.png)
